### PR TITLE
fix: renaming the base branch used in github workflows from 'main' to…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
… 'master'